### PR TITLE
Regenerate JSON to add 4 new links from README.md

### DIFF
--- a/app/everything-is-okay.json
+++ b/app/everything-is-okay.json
@@ -49,6 +49,10 @@
         {
             "title": "Baby Koala!!",
             "url": "https://www.youtube.com/watch?time_continue=2&v=cU8v4vZbFPc"
+        },
+        {
+            "title": "Otters Find A Butterfly",
+            "url": "https://www.youtube.com/watch?v=ICbG8LUDwaQ"
         }
     ],
     "Livestreams": [
@@ -73,6 +77,10 @@
         {
             "title": "Washing Machine Bounce!",
             "url": "https://www.youtube.com/watch?v=779fMc8ubOo"
+        },
+        {
+            "title": "Baby owl dance",
+            "url": "https://www.facebook.com/clipsofa/videos/1661839814029264/"
         }
     ],
     "WTF": [
@@ -99,6 +107,10 @@
         {
             "title": "Berries and Cream",
             "url": "https://www.youtube.com/watch?v=hsPFyoEpGVA"
+        },
+        {
+            "title": "Cult of the Party Parrot",
+            "url": "http://cultofthepartyparrot.com/"
         }
     ],
     "Gifs": [
@@ -187,6 +199,10 @@
         {
             "title": "Pumpkin the Raccoon",
             "url": "https://www.instagram.com/pumpkintheraccoon/"
+        },
+        {
+            "title": "Waffles the Corgi",
+            "url": "https://www.instagram.com/wafflescorgi/"
         }
     ],
     "Misc. Images": [


### PR DESCRIPTION
There were 4 new links in README.md that weren't present in `app/everything-is-okay.json` . This PR shows the results of running the command `npm run json`.

Side effect: the output seems to indicate that `app/scripts/json.js` appears to be generating the new `app/everything-is-okay.json` properly.
